### PR TITLE
Fix font rendering

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
 		<meta name="publisher" content="simplabs" />
     <title>{{page.title}}</title>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro:300,400,500" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
     <link rel="stylesheet" href="/css/vendor/font-awesome.min.css">
     <link rel="stylesheet" href="/css/main.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>

--- a/css/main.scss
+++ b/css/main.scss
@@ -409,4 +409,3 @@ html, body {
   max-width: 100%;
   overflow-x: hidden;
 }
-


### PR DESCRIPTION
There was just an incorrect URL. looks nicer now :)

<img width="806" alt="bildschirmfoto 2016-10-13 um 09 46 28" src="https://cloud.githubusercontent.com/assets/1175095/19340620/232d1934-912a-11e6-8835-6a1a9e095d69.png">
