### PR TITLE
don't load maps api via http

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,7 +687,7 @@ title: From Rails to Elixir & Phoenix Workshop
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-xs-12">
           <div id="map-canvas"></div>
-          <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
+          <script src="//maps.google.com/maps/api/js?sensor=false"></script>
           <script>
             google.maps.event.addDomListener(window, 'load', function() {
               var position = new google.maps.LatLng(52.514652, 13.387249);


### PR DESCRIPTION
@ganeshbsub: overlooked this earlier: please don't load scripts via HTTP but use protocol-neutral loading.

Otherwise we get this which doesn't look too good: 
<img width="454" alt="bildschirmfoto 2017-02-23 um 15 49 54" src="https://cloud.githubusercontent.com/assets/1510/23263851/bf288760-f9df-11e6-8d20-e3b062dd061c.png">
